### PR TITLE
入力処理を更新

### DIFF
--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -522,6 +522,9 @@ function s:ins(key, with_sticky = v:false) abort
         \ {'call': 's:suggest_reserve'},
         \ ])
 
+  if !empty(tuskk#opts#get('debug_log_path'))
+    call tuskk#utils#debug_log(feed, s:f('store#get_all'))
+  endif
   call s:feed(feed)
 endfunction
 

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -133,10 +133,9 @@ function tuskk#enable() abort
     " 変換が確定したらlatest_henkan_itemをクリアする
     " is_tuskk_completedがfalseなのにselectedが有効値の場合は
     " このプラグイン以外の候補が選択されたと判断して状態をクリアする
+          " \   let s:latest_henkan_item = {}
     autocmd CompleteDone *
-          \   if s:is_tuskk_completed()
-          \ |   let s:latest_henkan_item = {}
-          \ | elseif complete_info().selected >= 0
+          \   if complete_info().selected >= 0
           \ |   call tuskk#clear_state('CompleteDone')
           \ | endif
     " InsertLeaveだと<c-c>を使用した際に発火しないため
@@ -448,6 +447,7 @@ function s:backspace() abort
 endfunction
 
 function s:kakutei(fallback_key) abort
+  defer execute('let s:latest_henkan_item = {}')
   if !s:is_tuskk_completed() && complete_info().selected >= 0
     return "\<c-y>"
   endif

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -77,6 +77,9 @@ function s:phase_forget() abort
   let s:phase.reason = ''
 endfunction
 
+function s:let(name, value) abort
+  call execute($'let s:{a:name} = {string(a:value)}')
+endfunction
 let s:is_dict = {item -> type(item) == v:t_dict}
 let s:is_list = {item -> type(item) == v:t_list}
 let s:is_string = {item -> type(item) == v:t_string}

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -97,6 +97,7 @@ function s:feed(feeds = []) abort
   let feed = s:has_key(proc, 'call') ? [call(proc.call, get(proc, 'args', [])), ''][1]
         \ : s:has_key(proc, 'expr') ? call(proc.expr, get(proc, 'args', []))
         \ : s:has_key(proc, 'eval') ? eval(proc.eval)
+        \ : s:has_key(proc, 'exec') ? [execute(proc.exec), ''][1]
         \ : proc
   if s:is_list(feed)
     call extend(s:recursive_feed_list, feed, 0)

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -483,7 +483,7 @@ function s:henkan(fallback_key) abort
   return feed
 endfunction
 
-function s:feed_close_pum() abort
+function s:feed_ensure_close_pum() abort
   return pumvisible() && s:f('store#is_blank', 'machi') ? "\<c-e>" : ''
 endfunction
 function s:suggest_reserve() abort
@@ -523,7 +523,7 @@ function s:ins(key, with_sticky = v:false) abort
   let feed = [
         \ s:handle_spec(spec),
         \ {'call': 's:display_marks'},
-        \ {'expr': 's:feed_close_pum'},
+        \ {'expr': 's:feed_ensure_close_pum'},
         \ {'call': 's:suggest_reserve'},
         \ ]
 

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -509,7 +509,7 @@ function s:ins(key, with_sticky = v:false) abort
 
   let spec = s:f('spec#get', key, s:f('store#get', 'hanpa'))
 
-  if s:is_tuskk_completed() && pumvisible()
+  if s:is_tuskk_completed() && complete_info().selected >= 0
         \ && get(spec, 'mode', '') ==# ''
         \ && index(['kakutei', 'backspace', 'henkan'], get(spec, 'func', '')) < 0
     call insert(feed, {'expr': 's:handle_spec', 'args': [{'func': 'kakutei'}]})

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -83,7 +83,7 @@ let s:is_list = {item -> type(item) == v:t_list}
 let s:is_string = {item -> type(item) == v:t_string}
 let s:has_key = {item, key -> s:is_dict(item) && has_key(item, key)}
 let s:ensure_list = {item -> s:is_list(item) ? item : [item]}
-let s:throw = {msg -> execute($'throw {string(msg)}')}
+" let s:throw = {msg -> execute($'throw {string(msg)}')}
 let s:recursive_feed_list = []
 function s:feed(feeds = []) abort
   if !empty(a:feeds)
@@ -95,8 +95,11 @@ function s:feed(feeds = []) abort
   let feed = s:has_key(proc, 'call') ? [call(proc.call, get(proc, 'args', [])), ''][1]
         \ : s:has_key(proc, 'expr') ? call(proc.expr, get(proc, 'args', []))
         \ : s:has_key(proc, 'eval') ? eval(proc.eval)
-        \ : s:is_string(proc) ? proc
-        \ : s:throw('invalid proc ' .. string(proc))
+        \ : proc
+  if s:is_list(feed)
+    call extend(s:recursive_feed_list, feed, 0)
+    let feed = ''
+  endif
   return feedkeys(tuskk#utils#trans_special_key(feed) .. $"\<cmd>call {expand('<SID>')}feed()\<cr>", 'ni')
 endfunction
 

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -43,9 +43,10 @@ if !exists('s:phase')
       return
     endtry
 
-    let s:phase = { 'current': '', 'previous': '', 'reason': '', 'kouho': v:false }
-
-    execute 'autocmd FuncUndefined tuskk#* ++once source ' .. expand('<script>')
+    if !exists('s:phase')
+      let s:phase = { 'current': '', 'previous': '', 'reason': '', 'kouho': v:false }
+      execute 'autocmd FuncUndefined tuskk#* ++once source ' .. expand('<script>')
+    endif
   endfunction
 
   function tuskk#is_enabled() abort

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -131,7 +131,7 @@ function tuskk#enable() abort
 
   augroup tuskk_inner_augroup
     autocmd!
-    autocmd CompleteChanged * call s:on_complete_changed(v:event)
+    autocmd CompleteChanged * call s:on_complete_changed(v:event.completed_item)
     " 変換が確定したらlatest_henkan_itemをクリアする
     " is_tuskk_completedがfalseなのにselectedが有効値の場合は
     " このプラグイン以外の候補が選択されたと判断して状態をクリアする
@@ -301,14 +301,12 @@ function s:on_kakutei_special(user_data) abort
   call tuskk#utils#echoerr('未実装 ' .. special)
 endfunction
 
-function s:on_complete_changed(event) abort
-  let user_data = get(a:event.completed_item, 'user_data', {})
+function s:on_complete_changed(completed_item) abort
+  let user_data = get(a:completed_item, 'user_data', {})
 
   " user_dataがない、またはあってもyomiがない場合は
   " このプラグインとは関係ない候補
-  let s:latest_henkan_item = !s:has_key(user_data, 'yomi')
-        \ ? {}
-        \ : a:event.completed_item
+  let s:latest_henkan_item = s:has_key(user_data, 'yomi') ? a:completed_item : {}
 
   " kouhoを設定
   " 有効な候補が無い場合は空文字

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -57,7 +57,6 @@ if !exists('s:phase')
   finish
 endif
 
-
 function tuskk#open_user_jisyo() abort
   call s:f('user_jisyo#open')
 endfunction
@@ -319,81 +318,6 @@ function s:on_complete_changed(event) abort
   call s:display_marks()
 endfunction
 
-function s:get_spec(key) abort
-  " 先行入力と合わせて
-  "   完成した
-  "     辞書
-  "     文字列
-  "       半端がある
-  "       半端がない→半端が空文字として判断できる
-  "   完成していないが次なる先行入力の可能性がある
-  " 先行入力を無視して単体で
-  "   完成した→直前の先行入力を消すか分岐する必要がある
-  "     辞書
-  "     文字列
-  "       半端がある
-  "       半端がない→半端が空文字として判断できる
-  "   完成していないが次なる先行入力の可能性がある
-  " 完成していないし先行入力にもならない
-
-  " string: バッファに書き出す文字列
-  " store: ローマ字入力バッファの文字列（上書き）
-  " その他：関数など func / mode / expr
-  let spec = { 'string': '', 'store': '', 'key': a:key }
-
-  let current = s:f('store#get', 'hanpa') .. a:key
-  if has_key(tuskk#opts#get('kana_table'), current)
-    let spec.reason = 'combined:found'
-    " s:store.hanpaの残存文字と合わせて完成した場合
-    if s:is_dict(tuskk#opts#get('kana_table')[current])
-      call extend(spec, tuskk#opts#get('kana_table')[current])
-      return spec
-    endif
-    let [kana, roma; _rest] = tuskk#opts#get('kana_table')[current]->split('\A*\zs') + ['']
-    let spec.string = kana
-    let spec.store = roma
-    return spec
-  elseif has_key(tuskk#opts#get('preceding_keys_dict'), current)
-    let spec.reason = 'combined:probably'
-    " 完成はしていないが、先行入力の可能性がある場合
-    let spec.store = current
-    return spec
-  endif
-
-  " ここまでで値がヒットせず、put_hanpaがfalseなら、
-  " storeに残っていた半端な文字をバッファに載せずに消す
-  let spec.string = tuskk#opts#get('put_hanpa') ? s:f('store#get', 'hanpa') : ''
-
-  if has_key(tuskk#opts#get('kana_table'), a:key)
-    let spec.reason = 'alone:found'
-    " 先行入力を無視して単体で完成した場合
-    if s:is_dict(tuskk#opts#get('kana_table')[a:key])
-      call extend(spec, tuskk#opts#get('kana_table')[a:key])
-      " 値が辞書ならput_hanpaに関らずstringは削除
-      " storeに値を保存する
-      let spec.string = ''
-      let spec.store = s:f('store#get', 'hanpa')
-    else
-      let [kana, roma; _rest] = tuskk#opts#get('kana_table')[a:key]->split('\A*\zs') + ['']
-      let spec.string ..= kana
-      let spec.store = roma
-    endif
-
-    return spec
-  elseif has_key(tuskk#opts#get('preceding_keys_dict'), a:key)
-    let spec.reason = 'alone:probably'
-    " 完成はしていないが、単体で先行入力の可能性がある場合
-    let spec.store = a:key
-    return spec
-  endif
-
-  let spec.reason = 'unfound'
-  " ここまで完成しない（かなテーブルに定義が何もない）場合
-  let spec.string ..= a:key
-  let spec.store = ''
-  return spec
-endfunction
-
 function s:suggest_start() abort
   let exact_match = s:f('store#get', 'machi')->strcharlen() < tuskk#opts#get('suggest_prefix_match_minimum')
   call tuskk#henkan_list#update_suggest(s:f('store#get', 'machi'), exact_match)
@@ -586,7 +510,7 @@ function s:ins(key, with_sticky = v:false) abort
     return
   endif
 
-  let spec = s:get_spec(key)
+  let spec = s:f('spec#get', key, s:f('store#get', 'hanpa'))
 
   if s:is_tuskk_completed()
         \ && get(spec, 'mode', '') ==# ''

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -532,7 +532,7 @@ function s:ins(key, with_sticky = v:false) abort
 endfunction
 
 function s:handle_spec(args) abort
-  let spec = a:args
+  let spec = extend({'string': '', 'store': '', 'key': ''}, a:args)
 
   if !s:is_tuskk_completed() && get(spec, 'key', '') =~ '^[!-~]$' && tuskk#mode#is_direct()
     let spec = { 'string': spec.key, 'store': '', 'key': spec.key }

--- a/autoload/tuskk.vim
+++ b/autoload/tuskk.vim
@@ -10,26 +10,24 @@ endif
 " :h write-plugin-quickload
 if !exists('s:phase')
   " function import system
+  " s:f('file#func', arg1, arg2, ...)
   let s:sid_functions = {}
-  function s:import(filename) abort
-    let path = $"{expand('<script>:p:h')}/{a:filename}.vim"
-    execute 'source' path
-    let sid = getscriptinfo({'name': path})[0].sid
-    let functions = getscriptinfo({'sid': sid})[0].functions
-    let filename = substitute(a:filename, '.*/', '', '')
-    let prefix = '^<SNR>\d\+_export_'
-    for funcname in functions
-      if funcname =~ prefix
-        let keyname = filename .. substitute(funcname, prefix, '#', '')
-        let s:sid_functions[keyname] = funcname
-      endif
-    endfor
-  endfunction
   function s:f(funcname, ...) abort
     try
       return call(s:sid_functions[a:funcname], a:000)
     catch /^Vim\%((\a\+)\)\=:E716:/
-      call s:import('tuskk/' .. a:funcname->substitute('#.*', '', ''))
+      let filename = substitute(a:funcname, '#.*', '', '')
+      let path = $"{expand('<script>:p:h')}/tuskk/{filename}.vim"
+      execute 'source' path
+      let sid = getscriptinfo({'name': path})[0].sid
+      let functions = getscriptinfo({'sid': sid})[0].functions
+      let prefix = '^<SNR>\d\+_export_'
+      for funcname in functions
+        if funcname =~ prefix
+          let keyname = filename .. substitute(funcname, prefix, '#', '')
+          let s:sid_functions[keyname] = funcname
+        endif
+      endfor
       return call(s:sid_functions[a:funcname], a:000)
     endtry
   endfunction

--- a/autoload/tuskk/opts.vim
+++ b/autoload/tuskk/opts.vim
@@ -11,6 +11,7 @@ function s:create_file(path) abort
   call fnamemodify(a:path, ':p:h')
         \ ->iconv(&encoding, &termencoding)
         \ ->mkdir('p')
+  call writefile([], a:path)
 endfunction
 
 function s:export_parse(opts) abort
@@ -21,16 +22,18 @@ function s:export_parse(opts) abort
   let s:highlight_okuri = get(a:opts, 'highlight_okuri', 'ErrorMsg')
 
   " " デバッグログ出力先パス
-  " let s:debug_log_path = get(a:opts, 'debug_log_path', '')->expand()
-  " if !empty(s:debug_log_path)
-  "   if isdirectory(s:debug_log_path)
-  "     throw $"debug_log_path is directory {s:debug_log_path}"
-  "   endif
-  "   " 指定されたパスにファイルがなければ作成する
-  "   if glob(s:debug_log_path)->empty()
-  "     call s:create_file(s:debug_log_path)
-  "   endif
-  " endif
+  let s:debug_log_path = get(a:opts, 'debug_log_path', '')->expand()
+  if !empty(s:debug_log_path)
+    if isdirectory(s:debug_log_path)
+      throw $"debug_log_path is directory {s:debug_log_path}"
+    endif
+    " 指定されたパスにファイルがなければ作成する
+    if glob(s:debug_log_path)->empty()
+      " call s:create_file(s:debug_log_path)
+      echomsg s:create_file(s:debug_log_path)
+    endif
+    echomsg s:debug_log_path glob(s:debug_log_path)
+  endif
 
   " 自動補完待機時間 (負数の場合は自動補完しない)
   let s:suggest_wait_ms = get(a:opts, 'suggest_wait_ms', -1)

--- a/autoload/tuskk/opts.vim
+++ b/autoload/tuskk/opts.vim
@@ -21,18 +21,20 @@ function s:export_parse(opts) abort
   let s:highlight_kouho = get(a:opts, 'highlight_kouho', 'IncSearch')
   let s:highlight_okuri = get(a:opts, 'highlight_okuri', 'ErrorMsg')
 
-  " " デバッグログ出力先パス
+  " デバッグログ出力先パス
   let s:debug_log_path = get(a:opts, 'debug_log_path', '')->expand()
   if !empty(s:debug_log_path)
     if isdirectory(s:debug_log_path)
-      throw $"debug_log_path is directory {s:debug_log_path}"
+      throw $'ログファイルにディレクトリが指定されています。 {s:debug_log_path}'
     endif
     " 指定されたパスにファイルがなければ作成する
     if glob(s:debug_log_path)->empty()
-      " call s:create_file(s:debug_log_path)
-      echomsg s:create_file(s:debug_log_path)
+      if confirm($'{s:debug_log_path} にログファイルを作成してもよろしいですか？', "&Yes\n&No") != 1
+        throw $'ログファイルを読み込めませんでした。 {s:debug_log_path}'
+      endif
+      call s:create_file(s:debug_log_path)
     endif
-    echomsg s:debug_log_path glob(s:debug_log_path)
+    echomsg '[tuskk] デバッグログ出力先:' s:debug_log_path
   endif
 
   " 自動補完待機時間 (負数の場合は自動補完しない)

--- a/autoload/tuskk/spec.vim
+++ b/autoload/tuskk/spec.vim
@@ -1,0 +1,77 @@
+let s:is_dict = {item -> type(item) == v:t_dict}
+
+function s:export_get(key, preceding) abort
+  " 先行入力と合わせて
+  "   完成した
+  "     辞書
+  "     文字列
+  "       半端がある
+  "       半端がない→半端が空文字として判断できる
+  "   完成していないが次なる先行入力の可能性がある
+  " 先行入力を無視して単体で
+  "   完成した→直前の先行入力を消すか分岐する必要がある
+  "     辞書
+  "     文字列
+  "       半端がある
+  "       半端がない→半端が空文字として判断できる
+  "   完成していないが次なる先行入力の可能性がある
+  " 完成していないし先行入力にもならない
+
+  " string: バッファに書き出す文字列
+  " store: ローマ字入力バッファの文字列（上書き）
+  " その他：関数など func / mode / expr
+  let spec = { 'string': '', 'store': '', 'key': a:key }
+
+  let current = a:preceding .. a:key
+  if has_key(tuskk#opts#get('kana_table'), current)
+    let spec.reason = 'combined:found'
+    " s:store.hanpaの残存文字と合わせて完成した場合
+    if s:is_dict(tuskk#opts#get('kana_table')[current])
+      call extend(spec, tuskk#opts#get('kana_table')[current])
+      return spec
+    endif
+    let [kana, roma; _rest] = tuskk#opts#get('kana_table')[current]->split('\A*\zs') + ['']
+    let spec.string = kana
+    let spec.store = roma
+    return spec
+  elseif has_key(tuskk#opts#get('preceding_keys_dict'), current)
+    let spec.reason = 'combined:probably'
+    " 完成はしていないが、先行入力の可能性がある場合
+    let spec.store = current
+    return spec
+  endif
+
+  " ここまでで値がヒットせず、put_hanpaがfalseなら、
+  " storeに残っていた半端な文字をバッファに載せずに消す
+  let spec.string = tuskk#opts#get('put_hanpa') ? a:preceding : ''
+
+  if has_key(tuskk#opts#get('kana_table'), a:key)
+    let spec.reason = 'alone:found'
+    " 先行入力を無視して単体で完成した場合
+    if s:is_dict(tuskk#opts#get('kana_table')[a:key])
+      call extend(spec, tuskk#opts#get('kana_table')[a:key])
+      " 値が辞書ならput_hanpaに関らずstringは削除
+      " storeに値を保存する
+      let spec.string = ''
+      let spec.store = a:preceding
+    else
+      let [kana, roma; _rest] = tuskk#opts#get('kana_table')[a:key]->split('\A*\zs') + ['']
+      let spec.string ..= kana
+      let spec.store = roma
+    endif
+
+    return spec
+  elseif has_key(tuskk#opts#get('preceding_keys_dict'), a:key)
+    let spec.reason = 'alone:probably'
+    " 完成はしていないが、単体で先行入力の可能性がある場合
+    let spec.store = a:key
+    return spec
+  endif
+
+  let spec.reason = 'unfound'
+  " ここまで完成しない（かなテーブルに定義が何もない）場合
+  let spec.string ..= a:key
+  let spec.store = ''
+  return spec
+endfunction
+

--- a/autoload/tuskk/spec.vim
+++ b/autoload/tuskk/spec.vim
@@ -20,7 +20,7 @@ function s:export_get(key, preceding) abort
   " string: バッファに書き出す文字列
   " store: ローマ字入力バッファの文字列（上書き）
   " その他：関数など func / mode / expr
-  let spec = { 'string': '', 'store': '', 'key': a:key }
+  let spec = { 'key': a:key }
 
   let current = a:preceding .. a:key
   if has_key(tuskk#opts#get('kana_table'), current)

--- a/autoload/tuskk/store.vim
+++ b/autoload/tuskk/store.vim
@@ -1,4 +1,4 @@
-let s:store = { 'hanpa': '', 'choku': '', 'machi': '', 'okuri': '', 'kouho': '' }
+let s:store = { 'hanpa': '', 'machi': '', 'okuri': '', 'kouho': '' }
 
 function s:export_set(target, str) abort
   let s:store[a:target] = a:str
@@ -6,6 +6,10 @@ endfunction
 
 function s:export_get(target) abort
   return s:store[a:target]
+endfunction
+
+function s:export_get_all() abort
+  return s:store
 endfunction
 
 function s:export_clear(target = '') abort

--- a/autoload/tuskk/utils.vim
+++ b/autoload/tuskk/utils.vim
@@ -51,11 +51,8 @@ function tuskk#utils#echoerr(...) abort
   echohl NONE
 endfunction
 
-function tuskk#utils#debug_log(contents) abort
-  let contents = type(a:contents) == v:t_list ? mapnew(a:contents, 'json_encode(v:val)')
-        \ : type(a:contents) == v:t_dict ? json_encode(a:contents)
-        \ : [a:contents]
-  call writefile(contents, './debug.log', 'a')
+function tuskk#utils#debug_log(...) abort
+  call writefile(mapnew(a:000, 'json_encode(v:val)'), tuskk#opts#get('debug_log_path'), 'a')
 endfunction
 
 let consonant_list = [

--- a/debug.vim
+++ b/debug.vim
@@ -28,6 +28,7 @@ call tuskk#initialize({
       \ 'trailing_n': v:true,
       \ 'abbrev_ignore_case': v:true,
       \ 'put_hanpa': v:true,
+      \ 'debug_log_path': './local.log',
       \ })
 
 " edit ./autoload/tuskk.vim


### PR DESCRIPTION
fix #2 

- s:insおよびzengo等の処理を修正し、s:feedに必ずしも文字列を渡さないよう修正

- importの処理を自動で行うよう修正
- get_specの処理を別ファイルへ移動
- debug logを出力する機能を追加
- initializeを複数回実行してもautocmdが重複しないよう条件追加